### PR TITLE
Added Alpha-Beta Pruning

### DIFF
--- a/engine/globals.go
+++ b/engine/globals.go
@@ -1,6 +1,6 @@
 package engine
 
 const (
-	ENGINE_NAME   = "Lux 0.1"
+	ENGINE_NAME   = "Lux 0.2"
 	ENGINE_AUTHOR = "Sidhant Roymoulik"
 )

--- a/engine/search.go
+++ b/engine/search.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	CHECKMATE_VALUE int16 = 20000
+	CHECKMATE_VALUE int16 = 10000
 	MATE_CUTOFF     int16 = CHECKMATE_VALUE / 2
 	MAX_DEPTH       int16 = 100
 )
@@ -31,7 +31,7 @@ func (search *Search) Run() (best_move dragontoothmg.Move) {
 		depth <= int16(search.timer.MaxDepth) &&
 		search.timer.MaxNodeCount > 0; depth++ {
 
-		score := search.Negamax(depth, 0, &pv)
+		score := search.Negamax(depth, 0, -2*CHECKMATE_VALUE, 2*CHECKMATE_VALUE, &pv)
 
 		if search.timer.IsStopped() {
 			break
@@ -54,7 +54,7 @@ func (search *Search) Run() (best_move dragontoothmg.Move) {
 	return best_pv.GetPVMove()
 }
 
-func (search *Search) Negamax(depth int16, ply int16, pv *PV_Line) int16 {
+func (search *Search) Negamax(depth int16, ply int16, alpha int16, beta int16, pv *PV_Line) int16 {
 
 	search.nodes++
 
@@ -82,11 +82,19 @@ func (search *Search) Negamax(depth int16, ply int16, pv *PV_Line) int16 {
 	for _, move := range moves {
 
 		Unapply := search.board.Apply(move)
-		score := -search.Negamax(depth-1, ply+1, &child_pv)
+		score := -search.Negamax(depth-1, ply+1, -beta, -alpha, &child_pv)
 		Unapply()
 
 		if score > best_score {
 			best_score = score
+		}
+
+		if best_score >= beta {
+			break
+		}
+
+		if best_score > alpha {
+			alpha = best_score
 
 			pv.Update(move, child_pv)
 		}


### PR DESCRIPTION
Added a-b pruning to search

SPRT Results
```
Score of Lux 0.2 vs Lux 0.1: 33 - 1 - 19  [0.802] 53
...      Lux 0.2 playing White: 17 - 0 - 10  [0.815] 27
...      Lux 0.2 playing Black: 16 - 1 - 9  [0.788] 26
...      White vs Black: 18 - 16 - 19  [0.519] 53
Elo difference: 242.9 +/- 80.3, LOS: 100.0 %, DrawRatio: 35.8 %
SPRT: llr 2.99 (101.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```